### PR TITLE
Added function hashfileobject to hash file objects. hashfile now calls hashfileobject

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,19 @@ As a library:
     hashfile('foo.txt', sample_size=1000)
     'E\x0e3LI\x83\r~\xa3O\x9b\xbd\xd3[E\x23\x25'
 
+    # hash an already opened file
+    f = open('foo.txt')
+    hashfileobject(f)
+    'O\x9b\xbd\xd3[\x86\x9dE\x0e3LI\x83\r~\xa3'
+
+    # hash a file on a remote server
+    import paramiko
+    ssh = paramiko.SSHClient()
+    ssh.connect('host', username='username', password='verysecurepassword')
+    ftp = ssh.open_sftp()
+    hashfileobject(ftp.file('/path/to/remote/file/foo.txt'))
+    'O\x9b\xbd\xd3[\x86\x9dE\x0e3LI\x83\r~\xa3'
+
 Or from the command line:
 
 ``imosum *.jpg``

--- a/imohash/__init__.py
+++ b/imohash/__init__.py
@@ -1,1 +1,1 @@
-from .imohash import hashfile
+from .imohash import hashfile, hashfileobject

--- a/imohash/imohash.py
+++ b/imohash/imohash.py
@@ -15,9 +15,7 @@ SAMPLE_SIZE = 16 * 1024
 #Hashes an opened file object. Compatible with paramimo SFTPFile and regular files.
 def hashfileobject(f, sample_threshhold=SAMPLE_THRESHOLD, sample_size=SAMPLE_SIZE, hexdigest=False):
     #get file size from file object
-    f.seek(0, os.SEEK_END)
-    size = f.tell()
-    f.seek(0, os.SEEK_SET)
+    size = os.fstat(f.fileno()).st_size
 
     if size < sample_threshhold or sample_size < 1:
         data = f.read()

--- a/imohash/imohash.py
+++ b/imohash/imohash.py
@@ -26,8 +26,6 @@ def hashfileobject(f, sample_threshhold=SAMPLE_THRESHOLD, sample_size=SAMPLE_SIZ
         f.seek(-sample_size, os.SEEK_END)
         data += f.read(sample_size)
 
-    f.close()
-
     hash_tmp = mmh3.hash_bytes(data)
     hash_ = hash_tmp[7::-1] + hash_tmp[16:7:-1]
     enc_size = varint.encode(size)
@@ -36,8 +34,8 @@ def hashfileobject(f, sample_threshhold=SAMPLE_THRESHOLD, sample_size=SAMPLE_SIZ
     return binascii.hexlify(digest).decode() if hexdigest else digest
 
 def hashfile(filename, sample_threshhold=SAMPLE_THRESHOLD, sample_size=SAMPLE_SIZE, hexdigest=False):
-    f = open(filename, 'rb')
-    return hashfileobject(f, sample_threshhold, sample_size, hexdigest)
+    with open(filename, 'rb') as f:
+        return hashfileobject(f, sample_threshhold, sample_size, hexdigest)
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     long_description=long_description,
 
     # The project's main homepage.
-    url='https://github.com/kalafut/py-imohash',
+    url='https://github.com/wedsa5/py-imohash',
 
     # Author details
     author='Jim Kalafut',

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     long_description=long_description,
 
     # The project's main homepage.
-    url='https://github.com/wedsa5/py-imohash',
+    url='https://github.com/kalafut/py-imohash',
 
     # Author details
     author='Jim Kalafut',


### PR DESCRIPTION
Added function `hashfileobject` which takes all the functionality of `hashfile`. It accepts a file object instead of a file path. `hashfile` now opens the file from the path given and then calls `hashfileobject`. This allows hashing a file if you have the object itself and not the path.

This change was made specifically because of the need to hash a file on a remote server without downloading the whole thing. Using the `paramiko` module, you can open an sftp connection, then pass a remote path into `sftp.file(file_path)` which returns a file-like object with the same methods including `.read()` and `.seek()`. 
This way you can check the hash of a file on a remote server, download it, then use `hashfile` to verify it.