### PR TITLE
move hex size to the end

### DIFF
--- a/imohash/imohash.py
+++ b/imohash/imohash.py
@@ -31,7 +31,7 @@ def hashfileobject(f, sample_threshhold=SAMPLE_THRESHOLD, sample_size=SAMPLE_SIZ
     hash_tmp = mmh3.hash_bytes(data)
     hash_ = hash_tmp[7::-1] + hash_tmp[16:7:-1]
     enc_size = varint.encode(size)
-    digest = enc_size + hash_[len(enc_size):]
+    digest = hash_[len(enc_size):] + enc_size
 
     return binascii.hexlify(digest).decode() if hexdigest else digest
 


### PR DESCRIPTION
make the first few letters of hex string random enough
see the result of [check_randomness.py](https://github.com/kalafut/py-imohash/pull/6/commits/20976685033e6fe4960ab350156aa1c0ff4aaed7)

before:
```
{'0': 0,
 '1': 1,
 '2': 10,
 '3': 9,
 '4': 5,
 '5': 6,
 '6': 2,
 '7': 2,
 '8': 185,
 '9': 225,
 'a': 178,
 'b': 208,
 'c': 185,
 'd': 190,
 'e': 184,
 'f': 247}
```
after:
```
{'0': 108,
 '1': 83,
 '2': 110,
 '3': 106,
 '4': 96,
 '5': 109,
 '6': 102,
 '7': 70,
 '8': 105,
 '9': 100,
 'a': 103,
 'b': 106,
 'c': 106,
 'd': 116,
 'e': 99,
 'f': 118}
```
