### PR TITLE
fix hashfileobject support for StringIO

### DIFF
--- a/imohash/imohash.py
+++ b/imohash/imohash.py
@@ -25,7 +25,9 @@ def hashfileobject(f, sample_threshhold=SAMPLE_THRESHOLD, sample_size=SAMPLE_SIZ
         data = f.read(sample_size)
         f.seek(size//2)
         data += f.read(sample_size)
-        f.seek(-sample_size, os.SEEK_END)
+        # f.seek(-sample_size, os.SEEK_END)
+        tail = size - sample_size
+        f.seek(tail)
         data += f.read(sample_size)
 
     hash_tmp = mmh3.hash_bytes(data)


### PR DESCRIPTION
see issue #15 

To fix this issue negative offset seek needs to be avoided.

Here is the sample simple test reproduced after the fix

```python
>>> import io, string, imohash
>>> def test_io(data: str):
...     b = io.BytesIO(data.encode())
...     s = io.StringIO(data)
...     print("BytesIO", imohash.hashfileobject(b, hexdigest=True))
...     print("StringIO", imohash.hashfileobject(s, hexdigest=True))
...     return
... 
>>> data = string.ascii_letters
>>> len(data) > imohash.SAMPLE_THRESHOLD
False
>>> test_io(data)
BytesIO 34144d8f582760d9d50582629f7eee67
StringIO 34144d8f582760d9d50582629f7eee67
>>> 
>>> # increasing the data volume to exceed SAMPLE_THRESHOLD size
>>> data = string.ascii_letters * 3000
>>> len(data) > imohash.SAMPLE_THRESHOLD
>>> True
>>> test_io(data)
BytesIO e0c2098806ccaccd4fc164056e182f42
StringIO e0c2098806ccaccd4fc164056e182f42
```